### PR TITLE
Add supports for drawing column_groups for std

### DIFF
--- a/lux/action/column_group.py
+++ b/lux/action/column_group.py
@@ -115,6 +115,14 @@ def column_group(ldf):
                     else:
                         vis = cg_plotter.plot_col_vis(index_column_name, attribute)
                         collection.append(vis)
+                elif ldf[attribute].dtype ==  "object" and (attribute != "index"):
+                    if ((attribute in f_map) and (f_map[attribute] == "std") and 
+                        all(ldf[attribute].map(lambda x: isinstance(x, pd._libs.tslibs.timedeltas.Timedelta) or pd.api.types.is_float_dtype(x)))):
+                            timedelta_index  = ldf_flat[attribute].map(lambda x: isinstance(x, pd._libs.tslibs.timedeltas.Timedelta))
+                            ldf_flat[attribute][timedelta_index] = ldf_flat[attribute][timedelta_index] / pd.to_timedelta(1, unit='D')
+                            ldf_flat[attribute] = ldf_flat[attribute].astype("float64")
+                            vis = cg_plotter.plot_std_bar(ldf_flat, attribute)
+                            mean_collection.append(vis)
             vlst = VisList(collection, ldf_flat)
             vlst._collection.extend(mean_collection)
     # Note that we are not computing interestingness score here because we want to preserve the arrangement of the aggregated ldf

--- a/lux/implicit/cg_plotter.py
+++ b/lux/implicit/cg_plotter.py
@@ -29,6 +29,31 @@ def plot_col_vis(index_column_name, attribute):
     )
     return vis
 
+def plot_std_bar(df, attribute):
+    """
+    In:
+        df: results of df.std() (as a dataframe) after converting Timedelta object to float64 (in days)
+        attribute: the column name where df.std() is stored
+    
+    Returns:
+        CustomVis of this object
+    """
+    df = df.reset_index()
+
+    x_name = attribute
+    y_name = "index"
+    
+    v = alt.Chart(df).mark_bar().encode(
+        x = alt.X(x_name, type = "quantitative"),
+        y = alt.Y(y_name, type = "nominal"))
+
+
+    intent = [lux.Clause(x_name, data_type="quantitative", data_model="measure"),
+                  lux.Clause(y_name, data_type="nominal", data_model="dimension")]
+
+    cv = CustomVis(intent, v, df)
+    
+    return cv
 
 def plot_gb_mean_errorbar(df_m, df_s):
     """


### PR DESCRIPTION
Fixed the bug that `df.std()` could not show the corresponding bar graph, which is proposed in the #2 issue. 
