### PR TITLE
Improve the visualization for the series and the describe() of groupby objects

### DIFF
--- a/lux/action/column_group.py
+++ b/lux/action/column_group.py
@@ -51,6 +51,7 @@ def column_group(ldf):
     if len(ldf.history) and (
         ldf.history._events[-1].op_name == "describe"
         or ldf.history._events[-1].op_name == "value_counts"
+        or ldf.history._events[-1].op_name == "gb_describe"
     ):
         recommendation["collection"] = vlst
         return recommendation

--- a/lux/action/correlation.py
+++ b/lux/action/correlation.py
@@ -23,7 +23,7 @@ from IPython.core.debugger import set_trace
 
 
 # change ignore_transpose to false for now.
-def correlation(ldf: LuxDataFrame, ignore_transpose: bool = True):
+def correlation(ldf: LuxDataFrame, ignore_transpose: bool = True, **kwargs):
     """
     Generates bivariate visualizations that represent all pairwise relationships in the data.
 
@@ -89,6 +89,7 @@ def correlation(ldf: LuxDataFrame, ignore_transpose: bool = True):
 
     col_order = ldf.history.get_implicit_intent(ldf.columns)
     vlist.sort(intent_cols=col_order)
+    vlist.filter(**kwargs)
     vlist = vlist.showK()
     recommendation["collection"] = vlist
     return recommendation

--- a/lux/action/custom.py
+++ b/lux/action/custom.py
@@ -51,7 +51,7 @@ def custom(ldf):
     return recommendation
 
 
-def custom_actions(ldf):
+def custom_actions(ldf, **kwargs):
     """
     Generates user-defined vis based on globally defined actions.
 
@@ -59,6 +59,9 @@ def custom_actions(ldf):
     ----------
     ldf : lux.core.frame
         LuxDataFrame with underspecified intent.
+
+    filter_cols: list or None
+        attributes that must be used as one of channels in each returned chart from the action tab
 
     Returns
     -------
@@ -72,9 +75,10 @@ def custom_actions(ldf):
             if display_condition is None or (display_condition is not None and display_condition(ldf)):
                 args = lux.config.actions[action_name].args
                 if args:
-                    recommendation = lux.config.actions[action_name].action(ldf, args)
+                    recommendation = lux.config.actions[action_name].action(ldf, args, **kwargs)
+                    # filter_cols then passed to each action tab
                 else:
-                    recommendation = lux.config.actions[action_name].action(ldf)
+                    recommendation = lux.config.actions[action_name].action(ldf, **kwargs)
                 recommendations.append(recommendation)
         return recommendations
     else:

--- a/lux/action/enhance.py
+++ b/lux/action/enhance.py
@@ -20,7 +20,7 @@ from lux.vis.VisList import VisList
 from lux.vis.Vis import Vis
 
 
-def enhance(ldf):
+def enhance(ldf, **kwargs):
     """
     Given a set of vis, generates possible visualizations when an additional attribute is added to the current vis.
 
@@ -65,6 +65,7 @@ def enhance(ldf):
         vis.score = interestingness(vis, ldf)
 
     vlist.sort(intent_cols=implicit_col_list)
+    vlist.filter(**kwargs)
     vlist = vlist.showK()
 
     recommendation = {

--- a/lux/action/filter.py
+++ b/lux/action/filter.py
@@ -23,7 +23,7 @@ from lux.utils.utils import get_filter_specs
 from IPython.core.debugger import set_trace
 
 
-def add_filter(ldf):
+def add_filter(ldf, **kwargs):
     """
     Iterates over all possible values of a categorical variable and generates visualizations where each categorical value filters the data.
 
@@ -145,16 +145,13 @@ def add_filter(ldf):
         # remove the one with the exactly same filter as current vis
         arr = [_arr for _arr in arr if _arr != last.value]
         output.append(lux.Clause(last.attribute, last.attribute, arr))
-
     vlist = lux.vis.VisList.VisList(output, ldf)
     vlist_copy = lux.vis.VisList.VisList(output, ldf)
     for i in range(len(vlist_copy)):
         vlist[i].score = interestingness(vlist_copy[i], ldf)
     col_order = ldf.history.get_implicit_intent(ldf.columns)
     vlist.sort(intent_cols=col_order)
+    vlist.filter(**kwargs)
     vlist = vlist.showK()
-    if recommendation["action"] == "Similarity":
-        recommendation["collection"] = vlist
-    else:
-        recommendation["collection"] = vlist
+    recommendation["collection"] = vlist
     return recommendation

--- a/lux/action/generalize.py
+++ b/lux/action/generalize.py
@@ -19,7 +19,7 @@ from lux.utils import utils
 from lux.interestingness.interestingness import interestingness
 
 
-def generalize(ldf):
+def generalize(ldf, **kwargs):
     """
     Generates all possible visualizations when one attribute or filter from the current vis is removed.
 
@@ -95,5 +95,6 @@ def generalize(ldf):
     vlist.remove_duplicates()
     col_order = ldf.history.get_implicit_intent(ldf.columns)
     vlist.sort(remove_invalid=True, intent_cols=col_order)
+    vlist.filter(**kwargs)
     recommendation["collection"] = vlist
     return recommendation

--- a/lux/action/row_group.py
+++ b/lux/action/row_group.py
@@ -22,7 +22,7 @@ from lux.vis.VisList import VisList
 import pandas as pd
 
 
-def row_group(ldf):
+def row_group(ldf, **kwargs):
     recommendation = {
         "action": "Row Groups",
         "description": "Shows charts of possible visualizations with respect to the row-wise index.",

--- a/lux/action/temporal.py
+++ b/lux/action/temporal.py
@@ -21,7 +21,7 @@ from lux.interestingness.interestingness import interestingness
 from lux.utils import utils
 
 
-def temporal(ldf):
+def temporal(ldf, **kwargs):
     """
     Generates line charts for temporal fields at different granularities.
     Parameters

--- a/lux/action/temporal.py
+++ b/lux/action/temporal.py
@@ -68,6 +68,7 @@ def temporal(ldf, **kwargs):
 
     col_order = ldf.history.get_implicit_intent(ldf.columns)
     vlist.sort(intent_cols=col_order)
+    vlist.filter(**kwargs)
     recommendation["collection"] = vlist
     return recommendation
 

--- a/lux/action/univariate.py
+++ b/lux/action/univariate.py
@@ -18,7 +18,7 @@ import lux
 from lux.utils import utils
 
 
-def univariate(ldf, *args):
+def univariate(ldf, *args, **kwargs):
     """
     Generates bar chart distributions of different attributes in the dataframe.
 
@@ -98,5 +98,6 @@ def univariate(ldf, *args):
 
     col_order = ldf.history.get_implicit_intent(ldf.columns)
     vlist.sort(intent_cols=col_order)
+    vlist.filter(**kwargs)
     recommendation["collection"] = vlist
     return recommendation

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -1159,9 +1159,9 @@ class LuxDataFrame(pd.DataFrame):
         # But by specifying all possible parameters originally hidden in the *args and *kwargs,
         # we could know exactly wha subset is. 
         cols = subset if subset is not None else []
-        self.history.append_event("dropna", cols, rank_type="parent", child_df=ret_value, filt_key=None)
+        self.history.append_event("dropna", cols, rank_type="parent", child_df=ret_value, filt_key=None, filter_axis=axis)
         if ret_value is not None:  # i.e. inplace = True
-            ret_value.history.append_event("dropna", cols, rank_type="child", child_df=None, filt_key=None)
+            ret_value.history.append_event("dropna", cols, rank_type="child", child_df=None, filt_key=None, filter_axis=axis)
 
         return ret_value
 

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -461,9 +461,10 @@ class LuxDataFrame(pd.DataFrame):
                 self.index.nlevels >= 2 or self.columns.nlevels >= 2
             ):
                 from lux.action.custom import custom_actions
-
+                filter_cols = child.columns.to_list() if child is not None else None
                 # generate vis from globally registered actions and append to dataframe
-                custom_action_collection = custom_actions(self)
+                custom_action_collection = custom_actions(self, filter_cols=filter_cols)
+                # filter_cols specify what attributes the returned vis must have as one of its channels
                 for rec in custom_action_collection:
                     self._append_rec(rec_infolist, rec)
                 lux.config.update_actions["flag"] = False
@@ -475,11 +476,6 @@ class LuxDataFrame(pd.DataFrame):
             for rec_info in rec_infolist:
                 action_type = rec_info["action"]
                 vlist = rec_info["collection"]
-                if child is not None:
-                    # leave room for further inclusion of the dataframe.
-                    valid_columns = child.columns.to_list()
-                    # only select vis that have at least one attributes in valid_columns as one of its intent
-                    vlist = [vis for vis in vlist if any([len(vis.get_attr_by_attr_name(attr)) > 0 for attr in valid_columns])]
                 if len(vlist) > 0:
                     self._recommendation[action_type] = vlist
                     rec_info["collection"] = vlist

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -451,7 +451,9 @@ class LuxDataFrame(pd.DataFrame):
 
             # TODO: Rewrite these as register action inside default actions
             # set_trace()
-            if self.pre_aggregated:
+            if self.pre_aggregated and self.columns.nlevels == 1:
+                # add the second condition to avoid the visualization of a multi-column object
+                # for example, df.groupby("Origin").describe()
                 if self.columns.name is not None:
                     self._append_rec(rec_infolist, row_group(self))
                 self._append_rec(rec_infolist, column_group(self))

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -759,7 +759,11 @@ class LuxDataFrame(pd.DataFrame):
         check_import_lux_widget()
         import luxwidget  # widget code from other repo
 
-        hJSON = self.history.to_JSON() 
+        # we still want to see the history of the child for the series visualization.
+        if child is not None:
+            hJSON = child.history.to_JSON() 
+        else:
+            hJSON = self.history.to_JSON() 
         # it could be justified to use the parent history in the series case
         widgetJSON = self.to_JSON(input_current_vis=input_current_vis)
 

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -1136,7 +1136,11 @@ class LuxDataFrame(pd.DataFrame):
             ret_value = super(LuxDataFrame, self).isna(*args, **kwargs)
         self.history.append_event("isna", [], rank_type="parent")
         ret_value.history.append_event("isna", [], rank_type="child")
-
+        # column of names like "year", "weak" will be identified by the lux as "temporal" 
+        # no matter what the actual data type is. 
+        # This will cause an error in visualization of this column
+        # therefore we provide overriding data type manually here. 
+        ret_value.set_data_type({column:"nominal" for column in ret_value.columns})
         return ret_value
 
     def isnull(self, *args, **kwargs):
@@ -1144,6 +1148,11 @@ class LuxDataFrame(pd.DataFrame):
             ret_value = super(LuxDataFrame, self).isnull(*args, **kwargs)
         self.history.append_event("isna", [], rank_type="parent")
         # the isna call has already been logged because df.isna() is immediately called.
+        # in fact we do not need to override types here since the isna has already been called inside isnull
+        # we do this more due to the consideration of formalality
+        # the same rationale applies to the notnull and notna
+        # Besides we do not need to worry about the pd.isna since in this case, the df.isna is also finally called.
+        ret_value.set_data_type({column:"nominal" for column in ret_value.columns})
         return ret_value
 
     def notnull(self, *args, **kwargs):
@@ -1153,6 +1162,7 @@ class LuxDataFrame(pd.DataFrame):
         ret_value.history.delete_at(-1) # isna gets added before
         ret_value.history.append_event("notnull", [], rank_type="child")
 
+        ret_value.set_data_type({column:"nominal" for column in ret_value.columns})
         return ret_value
     
     def notna(self, *args, **kwargs):
@@ -1162,6 +1172,7 @@ class LuxDataFrame(pd.DataFrame):
         ret_value.history.delete_at(-1) # isna gets added before
         ret_value.history.append_event("notnull", [], rank_type="child")
 
+        ret_value.set_data_type({column:"nominal" for column in ret_value.columns})
         return ret_value
 
     def dropna(self, axis=0, how='any', thresh=None, subset=None, inplace=False):

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -419,6 +419,8 @@ class LuxDataFrame(pd.DataFrame):
                 f"Please convert the {is_series} into a flat "
                 f"table via pandas.DataFrame.reset_index."
             )
+        elif is_series == "Series" and self.columns[0] == "Unnamed":
+            self._message.add(f"Lux sets by default the name of this unnamed {is_series} as \"Unnamed\" during visualization")
         else:
             id_fields_str = ""
             inverted_data_type = lux.config.executor.invert_data_type(self.data_type)
@@ -748,7 +750,6 @@ class LuxDataFrame(pd.DataFrame):
 
         # get single function vis
         from lux.action.implicit_tab import implicit_mre
-
         implicit_mre_rec, curr_hist_index = implicit_mre(self, self.selectedHistoryIndex)
         implicit_mre_JSON = LuxDataFrame.rec_to_JSON([implicit_mre_rec])
 

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -1147,15 +1147,17 @@ class LuxDataFrame(pd.DataFrame):
 
         return ret_value
 
-    def dropna(self, *args, **kwargs):
+    def dropna(self, axis=0, how='any', thresh=None, subset=None, inplace=False):
         with self.history.pause():
-            ret_value = super(LuxDataFrame, self).dropna(*args, **kwargs)
+            ret_value = super(LuxDataFrame, self).dropna(axis, how, thresh, subset, inplace)
 
-        subset = kwargs.get("subset", None)
-        # we leave out one possible case when the user pass subset through *args style
+        # subset = kwargs.get("subset", None)
+        # In this way, we may leave out one possible case when the user pass subset through *args style
         # for example, df.dropna("rows", "all", 2, ["Origin"]) listing all parameters in order
         # but given there are in total three parameters before the subset, 
         # it seems this is a quite unusual choice
+        # But by specifying all possible parameters originally hidden in the *args and *kwargs,
+        # we could know exactly wha subset is. 
         cols = subset if subset is not None else []
         self.history.append_event("dropna", cols, rank_type="parent", child_df=ret_value, filt_key=None)
         if ret_value is not None:  # i.e. inplace = True

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -482,6 +482,7 @@ class LuxDataFrame(pd.DataFrame):
                     new_rec_infolist.append(rec_info)
 
             self._rec_info = new_rec_infolist
+            
             self.show_all_column_vis()
             self._widget = self.render_widget(child=child)
         # re-render widget for the current dataframe if previous rec is not recomputed
@@ -771,6 +772,22 @@ class LuxDataFrame(pd.DataFrame):
         else:
             implicit_mre_rec, curr_hist_index = implicit_mre(self, self.selectedHistoryIndex)
         implicit_mre_JSON = LuxDataFrame.rec_to_JSON([implicit_mre_rec])
+        # if len(implicit_mre_JSON) > 0:
+        #     print("implicit_mre_JSON")
+        #     for vis in implicit_mre_JSON[0]["vspec"]:
+        #         print("----------------------------------------------------")
+        #         if "layer" in vis:
+        #             for graph in vis["layer"]:
+        #                 print("--------------")
+        #                 print(graph.get("encoding", ""))
+        #                 print(graph.get("mark", ""))
+        #         elif ("encoding" in vis) and ("mark" in vis):
+        #             for channel in vis["encoding"]:
+        #                 print("************")
+        #                 print(channel)
+        #                 print(vis["encoding"][channel])
+        #             print("***%s***" % vis["mark"])
+
 
         return luxwidget.LuxWidget(
             currentVis=widgetJSON["current_vis"],

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -394,7 +394,7 @@ class LuxDataFrame(pd.DataFrame):
         # for example, df[["Origin", "Brand"]].describe() is of mixted types and satisfy all other conditions
         # the visualization of which will cause an error
         # on the other hand, if it is preaggregated, we will always create a vis in the maintain_recs()
-        if len(self.columns) > 1 and len(self.columns) < 4 and not self.pre_aggregated and self.intent == [] or self.intent is None:
+        if len(self.columns) > 1 and len(self.columns) < 4 and not self.pre_aggregated and (self.intent == [] or self.intent is None):
             vis = Vis(list(self.columns), self)
             if vis.mark != "":
                 vis._all_column = True

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -396,7 +396,7 @@ class LuxDataFrame(pd.DataFrame):
                 vis._all_column = True
                 self.current_vis = VisList([vis])
 
-    def maintain_recs(self, is_series="DataFrame"):
+    def maintain_recs(self, is_series="DataFrame", child=None):
         self.history.freeze()
         # check to see if globally defined actions have been registered/removed
         if lux.config.update_actions["flag"] == True:
@@ -466,14 +466,24 @@ class LuxDataFrame(pd.DataFrame):
 
             # Store _rec_info into a more user-friendly dictionary form
             self._recommendation = {}
+            new_rec_infolist = []
+            # intend to remove actions that have no vis after filtering.
             for rec_info in rec_infolist:
                 action_type = rec_info["action"]
                 vlist = rec_info["collection"]
+                if child is not None:
+                    # leave room for further inclusion of the dataframe.
+                    valid_columns = child.columns.to_list()
+                    # only select vis that have at least one attributes in valid_columns as one of its intent
+                    vlist = [vis for vis in vlist if any([len(vis.get_attr_by_attr_name(attr)) > 0 for attr in valid_columns])]
                 if len(vlist) > 0:
                     self._recommendation[action_type] = vlist
-            self._rec_info = rec_infolist
+                    rec_info["collection"] = vlist
+                    new_rec_infolist.append(rec_info)
+
+            self._rec_info = new_rec_infolist
             self.show_all_column_vis()
-            self._widget = self.render_widget()
+            self._widget = self.render_widget(child=child)
         # re-render widget for the current dataframe if previous rec is not recomputed
         self._recs_fresh = True
         self.history.unfreeze()
@@ -704,7 +714,7 @@ class LuxDataFrame(pd.DataFrame):
     def display_pandas(self):
         return self.to_pandas()
 
-    def render_widget(self, renderer: str = "altair", input_current_vis=""):
+    def render_widget(self, renderer: str = "altair", input_current_vis="", child=None):
         """
         Generate a LuxWidget based on the LuxDataFrame
 
@@ -745,12 +755,17 @@ class LuxDataFrame(pd.DataFrame):
         check_import_lux_widget()
         import luxwidget  # widget code from other repo
 
-        hJSON = self.history.to_JSON()
+        hJSON = self.history.to_JSON() 
+        # it could be justified to use the parent history in the series case
         widgetJSON = self.to_JSON(input_current_vis=input_current_vis)
 
         # get single function vis
         from lux.action.implicit_tab import implicit_mre
-        implicit_mre_rec, curr_hist_index = implicit_mre(self, self.selectedHistoryIndex)
+        if child is not None:
+            # if we are visualizing a child dataframe/series, we sill want to use its history to draw implicit tabs
+            implicit_mre_rec, curr_hist_index = implicit_mre(child)
+        else:
+            implicit_mre_rec, curr_hist_index = implicit_mre(self, self.selectedHistoryIndex)
         implicit_mre_JSON = LuxDataFrame.rec_to_JSON([implicit_mre_rec])
 
         return luxwidget.LuxWidget(

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -390,7 +390,11 @@ class LuxDataFrame(pd.DataFrame):
             rec_infolist.append(recommendations)
 
     def show_all_column_vis(self):
-        if len(self.columns) > 1 and len(self.columns) < 4 and self.intent == [] or self.intent is None:
+        # for a small dataframe, it is very likely to be aggregated and therefore consist of mixed types in one column
+        # for example, df[["Origin", "Brand"]].describe() is of mixted types and satisfy all other conditions
+        # the visualization of which will cause an error
+        # on the other hand, if it is preaggregated, we will always create a vis in the maintain_recs()
+        if len(self.columns) > 1 and len(self.columns) < 4 and not self.pre_aggregated and self.intent == [] or self.intent is None:
             vis = Vis(list(self.columns), self)
             if vis.mark != "":
                 vis._all_column = True

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -305,7 +305,8 @@ class LuxSeries(pd.Series):
     def value_counts(self, *args, **kwargs):
         ret_value = super(LuxSeries, self).value_counts(*args, **kwargs)
 
-        ret_value._parent_df = self
+        ret_value._parent_df = self 
+        # no need to use LuxDataFrame({name: self}) since the _parent_df won't be used in plotting implicit_tab
         ret_value._history = self._history.copy() # self._parent_df._history.copy()
         # is there a need to copy from the history of the grandparent?
         ret_value.pre_aggregated = True
@@ -346,6 +347,27 @@ class LuxSeries(pd.Series):
         else: 
             ret_value.history.append_event("describe", [name], rank_type="child")
         self.add_to_parent_history("describe", [name])
+        return ret_value
+
+
+    def isna(self, *args, **kwargs):
+        with self._history.pause():
+            ret_value = super(LuxSeries, self).isna(*args, **kwargs)
+
+        from lux.core.frame import LuxDataFrame
+        name = "Unnamed" if self.name is None else self.name
+        ret_value._parent_df = self
+        # no need to use LuxDataFrame({name: self}) since the _parent_df won't be used in plotting implicit_tab
+        # this is different from the part in describe, simply to faciliate the visualization.
+        ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
+
+        # add to history
+        self._history.append_event("isna", [name])
+        if ret_value.history.check_event(-1, op_name="col_ref", cols=[name]):
+            ret_value.history.edit_event(-1, "isna", [name], rank_type="child")
+        else: 
+            ret_value.history.append_event("isna", [name], rank_type="child")
+        self.add_to_parent_history("isna", [name])
         return ret_value
 
     def unique(self, *args, **kwargs):

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -173,9 +173,15 @@ class LuxSeries(pd.Series):
         if self.name is None:
             self.name = "Unnamed"
         child_df = None
-        if self._parent_df is not None and isinstance(self._parent_df, LuxDataFrame):
+        # for series, if its parent is a dataframe, then it is very likely to come from a column reference of it
+        # In such cases, we intend to show the visualization of the parent dataframe, 
+        # and select charts that are related to the attribute of this series.
+        # The exception is that for df.std() etc function, the returned value satisfies other conditions
+        # Even if we could show the parent dataframe, the attribute is not available.
+        # and what the user want is actually the column group graph.
+        if self._parent_df is not None and isinstance(self._parent_df, LuxDataFrame) and not self.pre_aggregated:
             ldf = self._parent_df
-            ldf._parent_df = None # do we need information about the grandparent?
+            ldf._parent_df = None #se do we need information about the grandparent?
             child_df = LuxDataFrame(self)
         else:
             ldf = LuxDataFrame(self)

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -311,14 +311,15 @@ class LuxSeries(pd.Series):
         ret_value.pre_aggregated = True
 
         # add to history 
-        self._history.append_event("value_counts", [self.name]) # df.col
-        if ret_value.history.check_event(-1, op_name="col_ref", cols=[self.name]):
-            ret_value.history.edit_event(-1, "value_counts", [self.name], rank_type="child")
+        name = "Unnamed" if self.name is None else self.name
+        self._history.append_event("value_counts", [name]) # df.col
+        if ret_value.history.check_event(-1, op_name="col_ref", cols=[name]):
+            ret_value.history.edit_event(-1, "value_counts", [name], rank_type="child")
         else: 
-            ret_value.history.append_event("value_counts", [self.name], rank_type="child")
+            ret_value.history.append_event("value_counts", [name], rank_type="child")
         ## otherwise, there are two logs, one for col_ref, the othere for value_counts
         ## because it directly copies the history of the parent dataframe
-        self.add_to_parent_history("value_counts", [self.name]) # df
+        self.add_to_parent_history("value_counts", [name]) # df
 
         return ret_value
 
@@ -330,9 +331,11 @@ class LuxSeries(pd.Series):
             if self._parent_df is not None:
                 self._parent_df.history.unfreeze()
 
-        from lux.core.frame import LuxDataFrame
+        from lux.core.frame import LuxDataFram
         name = "Unnamed" if self.name is None else self.name
-        ret_value._parent_df = LuxDataFrame({name: self})
+        ret_value._parent_df = LuxDataFrame({name: self}) 
+        # this is different from the part in value_counts, simply to faciliate the visualization.
+        # sinc in the boxplot, the whole dataframe is needed.
         ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
         ret_value.pre_aggregated = True
 

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -130,6 +130,36 @@ class LuxSeries(pd.Series):
 
         return lux.core.originalSeries(self, copy=False)
 
+    def set_data_type(self, types: dict):
+        """
+        Set the data type for this series
+        overriding the automatically-detected type inferred by Lux
+        which will happen in the _ipython_display when the series is converted to a dataframe
+        thanks to the finalize method, its _type_override will be copied to the dataframe then.
+
+        Parameters
+        ----------
+        types: dict
+            Dictionary that maps the name of this series to a specified Lux Type.
+            If the name is None, the convention is to use "Unnamed"
+            Possible options: "nominal", "quantitative", "id", and "temporal".
+
+        Example
+        ----------
+        df = pd.read_csv("https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/absenteeism.csv")
+        df.set_data_type({"ID":"id",
+                          "Reason for absence":"nominal"})
+        """
+        if self._type_override == None:
+            self._type_override = types
+        else:
+            self._type_override = {**self._type_override, **types}
+
+        for attr in types:
+            if types[attr] not in ["nominal", "quantitative", "id", "temporal"]:
+                raise ValueError(
+                    f'Invalid data type option specified for {attr}. Please use one of the following supported types: ["nominal", "quantitative", "id", "temporal"]'
+                )
 
     def _ipython_display_(self):
         from IPython.display import display
@@ -361,6 +391,10 @@ class LuxSeries(pd.Series):
         # this is different from the part in describe, simply to faciliate the visualization.
         ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
 
+        name = "Unnamed" if self.name is None else self.name
+        # manually set the data type to avoid mistakes like identifying the "Year" as temporal
+        # see set_data_type for a more detailed explanation why this works for the series
+        ret_value.set_data_type({name: "nominal"})
         # add to history
         self._log_events("isna", ret_value)
         return ret_value
@@ -375,6 +409,10 @@ class LuxSeries(pd.Series):
         # this is different from the part in describe, simply to faciliate the visualization.
         ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
 
+        name = "Unnamed" if self.name is None else self.name
+        # manually set the data type to avoid mistakes like identifying the "Year" as temporal
+        # see set_data_type for a more detailed explanation why this works for the series
+        ret_value.set_data_type({name: "nominal"})
         # add to history
         self._log_events("isna", ret_value)
         return ret_value
@@ -390,6 +428,11 @@ class LuxSeries(pd.Series):
         # this is different from the part in describe, simply to faciliate the visualization.
         ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
 
+        name = "Unnamed" if self.name is None else self.name
+        # manually set the data type to avoid mistakes like identifying the "Year" as temporal
+        # see set_data_type for a more detailed explanation why this works for the series
+        ret_value.set_data_type({name: "nominal"})
+
         # add to history
         self._log_events("notnull", ret_value)
         return ret_value
@@ -404,6 +447,11 @@ class LuxSeries(pd.Series):
         # this is different from the part in describe, simply to faciliate the visualization.
         ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
 
+        name = "Unnamed" if self.name is None else self.name
+        # manually set the data type to avoid mistakes like identifying the "Year" as temporal
+        # see set_data_type for a more detailed explanation why this works for the series
+        ret_value.set_data_type({name: "nominal"})
+        
         # add to history
         self._log_events("notnull", ret_value)
         return ret_value

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -204,7 +204,11 @@ class LuxSeries(pd.Series):
             # 2) Mixed type, often a result of a "row" acting as a series (df.iterrows, df.iloc[0])
             # Tolerant for NaNs + 1 type
             mixed_dtype = len(set([type(val) for val in self.values])) > 2
-            if ldf._pandas_only or is_dtype_series or mixed_dtype:
+            if ldf._pandas_only or is_dtype_series or (mixed_dtype and not ldf.pre_aggregated):
+                # if the series is pre-aggregated, then we allow the visualization even if the series consist of mixed types.
+                # for example, df["Origin"].describe().
+                # this also works in other cases since we have generally provided visualizations for the aggregated series
+                # in either column_group or implicit tab.
                 print(series_repr)
                 ldf._pandas_only = False
             else:

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -301,7 +301,7 @@ class LuxSeries(pd.Series):
     The fix is to catch this the first time a column is pulled into the cache and either clear the history or 
     something else
     """
-    def _log_events(self, op_name):
+    def _log_events(self, op_name, ret_value):
         # add to history 
         name = "Unnamed" if self.name is None else self.name
         self._history.append_event(op_name, [name]) # df.col
@@ -323,7 +323,7 @@ class LuxSeries(pd.Series):
         ret_value.pre_aggregated = True
 
         # add to history 
-        self._log_events("value_counts")
+        self._log_events("value_counts", ret_value)
         return ret_value
 
     def describe(self, *args, **kwargs):
@@ -343,7 +343,7 @@ class LuxSeries(pd.Series):
         ret_value.pre_aggregated = True
 
         # add to history
-        self._log_events("describe")
+        self._log_events("describe", ret_value)
         return ret_value
 
 
@@ -352,14 +352,13 @@ class LuxSeries(pd.Series):
             ret_value = super(LuxSeries, self).isna(*args, **kwargs)
 
         from lux.core.frame import LuxDataFrame
-        name = "Unnamed" if self.name is None else self.name
         ret_value._parent_df = self
         # no need to use LuxDataFrame({name: self}) since the _parent_df won't be used in plotting implicit_tab
         # this is different from the part in describe, simply to faciliate the visualization.
         ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
 
         # add to history
-        self._log_events("isna")
+        self._log_events("isna", ret_value)
         return ret_value
 
     def isnull(self, *args, **kwargs):
@@ -367,15 +366,45 @@ class LuxSeries(pd.Series):
             ret_value = super(LuxSeries, self).isnull(*args, **kwargs)
 
         from lux.core.frame import LuxDataFrame
-        name = "Unnamed" if self.name is None else self.name
         ret_value._parent_df = self
         # no need to use LuxDataFrame({name: self}) since the _parent_df won't be used in plotting implicit_tab
         # this is different from the part in describe, simply to faciliate the visualization.
         ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
 
         # add to history
-        self._log_events("isna")
+        self._log_events("isna", ret_value)
         return ret_value
+
+
+    def notnull(self, *args, **kwargs):
+        with self._history.pause():
+            ret_value = super(LuxSeries, self).notnull(*args, **kwargs)
+
+        from lux.core.frame import LuxDataFrame
+        ret_value._parent_df = self
+        # no need to use LuxDataFrame({name: self}) since the _parent_df won't be used in plotting implicit_tab
+        # this is different from the part in describe, simply to faciliate the visualization.
+        ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
+
+        # add to history
+        self._log_events("notnull", ret_value)
+        return ret_value
+
+    def notna(self, *args, **kwargs):
+        with self._history.pause():
+            ret_value = super(LuxSeries, self).notna(*args, **kwargs)
+
+        from lux.core.frame import LuxDataFrame
+        ret_value._parent_df = self
+        # no need to use LuxDataFrame({name: self}) since the _parent_df won't be used in plotting implicit_tab
+        # this is different from the part in describe, simply to faciliate the visualization.
+        ret_value._history = self._history.copy() # seems no need to inherit the history of the grandparent.
+
+        # add to history
+        self._log_events("notnull", ret_value)
+        return ret_value
+
+
 
     def unique(self, *args, **kwargs):
         """

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -366,8 +366,9 @@ class LuxSeries(pd.Series):
             ret_value = np.array(self.unique_values[self.name])
         else:
             ret_value = super(LuxSeries, self).unique(*args, **kwargs)
-        self._history.append_event("unique", [self.name])
-        self.add_to_parent_history("unique", [self.name])
+        name = "Unnamed" if self.name is None else self.name
+        self._history.append_event("unique", [name])
+        self.add_to_parent_history("unique", [name])
 
         return ret_value
 

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -191,12 +191,13 @@ class LuxSeries(pd.Series):
         # it involves the filter, and including the charts for the parent dataframe (df in this case) will be confusing
         # are charts about the dataframe before or after the visualization?
         # therefore, we choose not to including the charts for the parent dataframe in this case
-        mre_op_name = self.history.get_mre([self.name])[0].op_name
+        most_recent_event, hist_index = self.history.get_mre([self.name])
+        most_recent_op = most_recent_event.op_name if most_recent_event is not None else None
         if (self._parent_df is not None and 
                 isinstance(self._parent_df, LuxDataFrame) and 
                 not self.pre_aggregated
-                and mre_op_name != "iloc"
-                and mre_op_name != "loc"
+                and most_recent_op != "iloc"
+                and most_recent_op != "loc"
             ):
             ldf = self._parent_df
             ldf._parent_df = None #se do we need information about the grandparent?

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -89,10 +89,12 @@ def process_value_counts(signal, ldf):
         array: []
             which columns were used
     """
+    set_trace()
     try:
-        rank_type = signal.kwargs["rank_type"]
+        rank_type = signal.kwargs.get("rank_type", None)
+        # in the unique case, there is no parent but we still want the corresponding visualization.
         c_name = signal.cols[0]
-        if rank_type == "parent" and not ldf.pre_aggregated:
+        if ((rank_type == "parent") or rank_type is None) and not ldf.pre_aggregated:
             # due to the most recent event is set to be non-parent, 
             # this part of the conditional statement actually is never used.
             if ldf.data_type[c_name] == "quantitative":

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -57,6 +57,7 @@ def generate_vis_from_signal(signal: Event, ldf: LuxDataFrame, ranked_cols=[]):
         or signal.op_name == "slice"
         or signal.op_name == "gb_filter"
         or signal.op_name == "loc"
+        or signal.op_name == "iloc"
     ):
 
         vis_list, used_cols = process_filter(signal, ldf, ranked_cols)

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -3,6 +3,7 @@ from lux.vis.Vis import Vis
 from lux.vis.CustomVis import CustomVis
 from lux.history.event import Event
 from lux.core.frame import LuxDataFrame
+from lux.core.series import LuxSeries
 import lux.utils.defaults as lux_default
 
 from lux.implicit import cg_plotter
@@ -163,7 +164,11 @@ def process_describe(signal, ldf):
         or  (len(ldf) == 11 and all(ldf.index == ["count", "unique", "top", "freq", "mean", "std", "min", "25%", "50%", "75%", "max"])) # the mixed case
         ) 
     ):
-        plot_df = ldf._parent_df
+        if isinstance(ldf._parent_df, LuxSeries):
+            name = "Unnamed" if ldf._parent_df.name is None else ldf._parent_df.name
+            plot_df = LuxDataFrame({name: ldf._parent_df})
+        else:
+            plot_df = ldf._parent_df
     else:
         plot_df = ldf
     

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -212,6 +212,7 @@ def process_filter(signal, ldf, ranked_cols, num_vis_cap=5):
     rank_type = signal.kwargs.get("rank_type", None)
     child_df = signal.kwargs.get("child_df", None)
     parent_mask = signal.kwargs.get("filt_key", None)
+    filter_axis = signal.kwargs.get("filter_axis", None)
 
     # assign parent and child
     p_df, c_df = None, None
@@ -225,7 +226,8 @@ def process_filter(signal, ldf, ranked_cols, num_vis_cap=5):
             p_df = ldf._parent_df
         c_df = ldf
 
-    if(set(p_df.columns) != set(c_df.columns)):
+    if filter_axis == 0 or filter_axis == "columns":
+        # we add this conditional statement to avoid drawing filter visualization for dropna(axis="columns")
         return VisList([], ldf), []
     else:
         # in the following, we assume that the filter is applied by rows instead of by columns

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -89,7 +89,6 @@ def process_value_counts(signal, ldf):
         array: []
             which columns were used
     """
-    set_trace()
     try:
         rank_type = signal.kwargs.get("rank_type", None)
         # in the unique case, there is no parent but we still want the corresponding visualization.

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -93,6 +93,8 @@ def process_value_counts(signal, ldf):
         rank_type = signal.kwargs["rank_type"]
         c_name = signal.cols[0]
         if rank_type == "parent" and not ldf.pre_aggregated:
+            # due to the most recent event is set to be non-parent, 
+            # this part of the conditional statement actually is never used.
             if ldf.data_type[c_name] == "quantitative":
                 clse = lux.Clause(attribute=c_name, mark_type="histogram")
             else:

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -269,7 +269,8 @@ def get_col_recs(parent_df, child_df):
 
     # TODO store this on the df so dont have to recalc so much
     # TODO calc distance for 2d as well
-    for c in parent_df.columns:
+    valid_columns = set(parent_df.columns) & set(child_df.columns)
+    for c in valid_columns:
         p_data = parent_df[c].dropna().values
         c_data = child_df[c].dropna().values
 

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -69,7 +69,7 @@ def generate_vis_from_signal(signal: Event, ldf: LuxDataFrame, ranked_cols=[]):
     elif signal.op_name == "isna" or signal.op_name == "notnull":
         vis_list, used_cols = process_null_plot(signal, ldf)
 
-    elif signal.cols:  # generic recs
+    elif signal.cols and not ldf.pre_aggregated:  # generic recs
         vis_list, used_cols = process_generic(signal, ldf)
 
     ldf.history.unfreeze()

--- a/lux/implicit/implicit_plotter.py
+++ b/lux/implicit/implicit_plotter.py
@@ -225,30 +225,36 @@ def process_filter(signal, ldf, ranked_cols, num_vis_cap=5):
             p_df = ldf._parent_df
         c_df = ldf
 
-    # get mask
-    if parent_mask is not None:
-        mask = parent_mask
+    if(set(p_df.columns) != set(c_df.columns)):
+        return VisList([], ldf), []
     else:
-        mask, same_cols = compute_filter_diff(p_df, c_df)
+        # in the following, we assume that the filter is applied by rows instead of by columns
+        # in other words, only rows are dropped, so the columns of the parernt and the child should be the same
+        # get mask
+        if parent_mask is not None:
+            # this information is available only in the `_getitem_bool_array` case
+            mask = parent_mask
+        else:
+            mask, same_cols = compute_filter_diff(p_df, c_df)
 
-    # get cols with large dist change
-    vis_cols = get_col_recs(p_df, c_df)
+        # get cols with large dist change
+        vis_cols = get_col_recs(p_df, c_df)
 
-    # populate vis
-    all_used_cols = set()
-    chart_list = []
-    if rank_type == "child":
-        chart_list.append(plot_filter_count(p_df, mask))
+        # populate vis
+        all_used_cols = set()
+        chart_list = []
+        if rank_type == "child":
+            chart_list.append(plot_filter_count(p_df, mask))
 
-    if p_df is not None:
-        for c in vis_cols[:num_vis_cap]:
-            _v = plot_filter(p_df, [c], mask)
-            chart_list.append(_v)
-            all_used_cols.add(c)
+        if p_df is not None:
+            for c in vis_cols[:num_vis_cap]:
+                _v = plot_filter(p_df, [c], mask)
+                chart_list.append(_v)
+                all_used_cols.add(c)
 
-    vl = VisList(chart_list)
+        vl = VisList(chart_list)
 
-    return vl, list(all_used_cols)
+        return vl, list(all_used_cols)
 
 
 def get_col_recs(parent_df, child_df):

--- a/lux/vis/VisList.py
+++ b/lux/vis/VisList.py
@@ -275,6 +275,20 @@ class VisList:
             k = abs(k)
             return VisList(self._collection[:k])
 
+    def filter(self, **kwargs):
+        """
+        Filter vis objects that have attributes as one of its channels. 
+        Use kwargs to accommodate more possible filter strategies later.
+
+        Parameters
+        ----------
+        filter_cols
+                attributes we are intereted in
+        """
+        filter_cols = kwargs.get("filter_cols", None)
+        if filter_cols is not None:
+            self._collection = [vis for vis in self._collection if any([len(vis.get_attr_by_attr_name(attr)) > 0 for attr in filter_cols])]
+
     def normalize_score(self, invert_order=False):
         try:
             max_score = max(list(self.get("score")))


### PR DESCRIPTION
1.  Present visualizations for the `describe()` function of the LuxGroupBy. Support the three primary cases of usage. The logic for each case is somehow complicated and very specific, which might be acceptable since more advanced methods are rarely used.

-  df.groupby("Origin").describe()
- df.groupby("Origin")["Cylinders"].describe()
- df.groupby("Origin").describe()[["Cylinders"]]

2. Support the visualization of series, which includes relevant recommended graphs from its parent dataframe

- When possible, pass the parent dataframe of the series to the __miantain_rec function. 
- Filter graphs that have the attribute of the series as one of their channels inside each action function before the `showK()`.